### PR TITLE
Add advanced mail operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npx -y @smithery/cli@latest install @Dhravya/apple-mcp --client cursor
   - Schedule emails for future delivery
   - List and manage scheduled emails
   - Check unread email counts globally or per mailbox
+  - List configured accounts with type and status
+  - Retrieve detailed account settings
+  - Display mailbox hierarchy and properties
+  - List messages from a specific mailbox with filters
 - Reminders:
   - List all reminders and reminder lists
   - Search for reminders by text

--- a/tools.ts
+++ b/tools.ts
@@ -86,8 +86,19 @@ const CONTACTS_TOOL: Tool = {
       properties: {
         operation: {
           type: "string",
-          description: "Operation to perform: 'unread', 'search', 'send', 'mailboxes', or 'accounts'",
-          enum: ["unread", "search", "send", "mailboxes", "accounts"]
+          description: "Operation to perform: 'unread', 'search', 'send', 'mailboxes', 'accounts', 'accountSummaries', 'accountDetails', 'mailboxTree', 'mailboxProps', or 'messages'",
+          enum: [
+            "unread",
+            "search",
+            "send",
+            "mailboxes",
+            "accounts",
+            "accountSummaries",
+            "accountDetails",
+            "mailboxTree",
+            "mailboxProps",
+            "messages"
+          ]
         },
         account: {
           type: "string",
@@ -100,6 +111,18 @@ const CONTACTS_TOOL: Tool = {
         limit: {
           type: "number",
           description: "Number of emails to retrieve (optional, for unread and search operations)"
+        },
+        unreadOnly: {
+          type: "boolean",
+          description: "Only return unread messages (optional for messages operation)"
+        },
+        startDate: {
+          type: "string",
+          description: "Start date filter in ISO format (optional for messages operation)"
+        },
+        endDate: {
+          type: "string",
+          description: "End date filter in ISO format (optional for messages operation)"
         },
         searchTerm: {
           type: "string",


### PR DESCRIPTION
## Summary
- extend README features for mail
- expand mail tool schema with new operations
- expose advanced mail operations in server

## Testing
- `bunx tsc -p tsconfig.json --noEmit` *(fails: `bunx: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683d62cf0c548323b6afaf6d48e784d1