### PR TITLE
Add lint and test commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 ## Commands
 - `bun run dev` - Start the development server
-- No specific test or lint commands defined in package.json
+- `bun run lint` - Check code style with ESLint
+- `bun test` - Run the test suite
 
 ## Code Style
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import parser from "@typescript-eslint/parser";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        project: "./tsconfig.json",
+        sourceType: "module",
+      },
+    },
+    plugins: { "@typescript-eslint": ts },
+    rules: {
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -23,11 +23,16 @@
     "apple-mcp": "./index.ts"
   },
   "scripts": {
-    "dev": "bun run index.ts"
+    "dev": "bun run index.ts",
+    "lint": "bun x eslint . --ext .ts",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/node": "^22.13.4"
+    "@types/node": "^22.13.4",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^7.0.1",
+    "@typescript-eslint/eslint-plugin": "^7.0.1"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "bun:test";
+
+describe("basic math", () => {
+  it("adds numbers", () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add ESLint configuration for TypeScript
- set up placeholder bun test
- document new scripts in CLAUDE.md
- expose lint/test scripts via package.json

## Testing
- `bun test`
- `bun run lint` *(fails: Cannot find package '@eslint/js')*
- `bun install` *(fails: 403 when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_683f433a1aa8832397c1efd78e45fbb2