### PR TITLE
Add mail message helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npx -y @smithery/cli@latest install @Dhravya/apple-mcp --client cursor
   - Retrieve detailed account settings
   - Display mailbox hierarchy and properties
   - List messages from a specific mailbox with filters
+  - Fetch message content, metadata, and attachments by message ID
 - Reminders:
   - List all reminders and reminder lists
   - Search for reminders by text
@@ -129,6 +130,14 @@ find all the notes related to AI and send it to my girlfriend
 
 ```
 create a reminder to "Buy groceries" for tomorrow at 5pm
+```
+
+```
+get message content for ID "ABC123" from account "iCloud" mailbox "Inbox"
+```
+
+```
+save attachments from message "XYZ789" in mailbox "Work" to ~/Downloads
 ```
 
 ## Local Development

--- a/tools.ts
+++ b/tools.ts
@@ -86,7 +86,7 @@ const CONTACTS_TOOL: Tool = {
       properties: {
         operation: {
           type: "string",
-          description: "Operation to perform: 'unread', 'search', 'send', 'mailboxes', 'accounts', 'accountSummaries', 'accountDetails', 'mailboxTree', 'mailboxProps', or 'messages'",
+          description: "Operation to perform: 'unread', 'search', 'send', 'mailboxes', 'accounts', 'accountSummaries', 'accountDetails', 'mailboxTree', 'mailboxProps', 'messages', 'messageContent', 'messageMetadata', or 'messageAttachments'",
           enum: [
             "unread",
             "search",
@@ -97,7 +97,10 @@ const CONTACTS_TOOL: Tool = {
             "accountDetails",
             "mailboxTree",
             "mailboxProps",
-            "messages"
+            "messages",
+            "messageContent",
+            "messageMetadata",
+            "messageAttachments"
           ]
         },
         account: {
@@ -147,6 +150,14 @@ const CONTACTS_TOOL: Tool = {
         bcc: {
           type: "string",
           description: "BCC email address (optional for send operation)"
+        },
+        messageId: {
+          type: "string",
+          description: "ID of the message for content, metadata or attachments operations",
+        },
+        saveDir: {
+          type: "string",
+          description: "Directory to save attachments (optional for messageAttachments)",
         }
       },
       required: ["operation"]


### PR DESCRIPTION
## Summary
- implement message content, metadata and attachment utilities
- expose new mail operations in index and tool schema
- document new mail features

## Testing
- `npx --yes typescript --version` *(fails: 403 Forbidden)*
- `bunx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f46d116f08323ae491bed55a9ae51