### PR TITLE
Fix mail arg validation bug

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1421,11 +1421,15 @@ function isMailArgs(args: unknown): args is {
   includeHeaders?: boolean;
 } {
   if (typeof args !== "object" || args === null) return false;
-  
+
   const {
     operation,
     account,
     mailbox,
+    parentMailbox,
+    name,
+    newName,
+    targetParent,
     limit,
     unreadOnly,
     startDate,


### PR DESCRIPTION
## Summary
- fix missing destructuring in isMailArgs to prevent `parentMailbox` reference error

## Testing
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6841b46011e0832398a40c4e47a355c4